### PR TITLE
Fix issue when only one read_lengh is provided

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -67,7 +67,7 @@ if (!params.read_length_from && params.read_length_to){exit 1, "Error: Missing -
 
 if (params.read_length) {
   Channel
-      .from(params.read_length.split(','))
+      .from(params.read_length.toString().split(','))
       .set { ch_read_length }
 }
 


### PR DESCRIPTION
## Overview

fixes #6 

## To test
```
git clone https://github.com/TheJacksonLaboratory/Star_indices
cd Star_indices
git checkout dev
# this will fail:
nextflow run . -profile test --read_length_from false --read_length_to false --read_length 100

git checkout fix-read_length
# Nowthis will succeed:
nextflow run . -profile test --read_length_from false --read_length_to false --read_length 100
```
## CloudOS run:
https://cloudos.lifebit.ai/public/jobs/6167322a1b866a01d6978d6a