### PR TITLE
add profile for sumner

### DIFF
--- a/NF_Star_Index.config
+++ b/NF_Star_Index.config
@@ -1,0 +1,12 @@
+params {
+  // Input data
+  reference = '/projects/anczukow-lab/reference_genomes/mouse_black6/Gencode/GRCm38.primary_assembly.genome.fa'
+  annotation = '/projects/anczukow-lab/reference_genomes/mouse_black6/Gencode/gencode.vM23.primary_assembly.annotation.gtf'
+
+  // Read Length Options
+  read_length = 150
+  
+  // Star Options
+  star_container = 'quay.io/lifebitai/star_indices:2.7.9a'
+  memory = 35.GB
+}

--- a/conf/sumner.config
+++ b/conf/sumner.config
@@ -1,0 +1,16 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running on JAX's Sumner HPC
+ * -------------------------------------------------
+ * Base config needed for running with -profile sumner
+ */
+
+process {
+  executor = 'slurm'
+  beforeScript = 'module load singularity'
+}
+singularity {
+  enabled = true
+  cacheDir = "/projects/anczukow-lab/.singularity_cache/"
+  autoMounts = true
+}

--- a/main.pbs
+++ b/main.pbs
@@ -3,11 +3,11 @@
 #SBATCH -e splicing.%j.err
 #SBATCH --mail-type=END,FAIL
 #SBATCH --mail-user=$USER@jax.org
-#SBATCH --mem=20000
+#SBATCH --mem=35000
 #SBATCH --cpus-per-task=4
 #SBATCH -p compute
 #SBATCH -q batch
-#SBATCH -t 3-00:00:00 
+#SBATCH -t 1-00:00:00 
 
 cd $SLURM_SUBMIT_DIR
 date;hostname;pwd
@@ -16,12 +16,9 @@ module load singularity
 
 curl -fsSL get.nextflow.io | bash
 
-./nextflow run /projects/anczukow-lab/splicing_pipeline/Star_indices/main.nf \
+./nextflow run /projects/anczukow-lab/star_index_pipeline/Star_indices/main.nf \
 	--outdir ${SLURM_SUBMIT_DIR} \
-	-config CHANGE_ME.config \
+	-config NF_Star_Index.config \
 	-profile sumner -resume \
         -with-report report.html \
-        -with-trace trace.txt \
-        -with-timeline timeline.html \
-        -with-dag DAG.png
-
+        -with-timeline timeline.html 

--- a/main.pbs
+++ b/main.pbs
@@ -1,0 +1,27 @@
+#!/bin/bash
+#SBATCH -o splicing.%j.out
+#SBATCH -e splicing.%j.err
+#SBATCH --mail-type=END,FAIL
+#SBATCH --mail-user=$USER@jax.org
+#SBATCH --mem=20000
+#SBATCH --cpus-per-task=4
+#SBATCH -p compute
+#SBATCH -q batch
+#SBATCH -t 3-00:00:00 
+
+cd $SLURM_SUBMIT_DIR
+date;hostname;pwd
+
+module load singularity
+
+curl -fsSL get.nextflow.io | bash
+
+./nextflow run /projects/anczukow-lab/splicing_pipeline/Star_indices/main.nf \
+	--outdir ${SLURM_SUBMIT_DIR} \
+	-config CHANGE_ME.config \
+	-profile sumner -resume \
+        -with-report report.html \
+        -with-trace trace.txt \
+        -with-timeline timeline.html \
+        -with-dag DAG.png
+

--- a/nextflow.config
+++ b/nextflow.config
@@ -90,6 +90,7 @@ process {
     maxForks = params.maxForks
     container = params.container
     errorStrategy = params.errorStrategy
+    time = params.max_time
   
     withName: STAR {
         disk = params.disk

--- a/nextflow.config
+++ b/nextflow.config
@@ -76,6 +76,7 @@ profiles {
     google {includeConfig 'conf/google.config'}
     test {includeConfig 'conf/test.config'}
     local {includeConfig 'conf/test.config'}
+    sumner {includeConfig 'conf/sumner.config'}
 }
 
 // 3. Process


### PR DESCRIPTION
## Overview

This PR adds config file to be run on JAX sumner cluster. 

## Changes

- Adds `conf/sumner.config` 
- Adds `main.pbs`
- Added new profile option `-profile sumner`

## Notes

In `main.pbs`, the configuration should be changed for an appropriate one