### PR TITLE
Fix typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This workflow minimal requirements are at least 1 CPUs and 20-60GB of memory (de
 
 The typical command for running the pipeline is as follows:
 
-    nextflow run main.nf --reference sample.fa --gtf sample.gtf [Options]
+    nextflow run main.nf --reference sample.fa --annotation sample.gtf [Options]
 
     Inputs Options:
     --reference         Reference file (fasta, can be .gz-compressed)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The typical command for running the pipeline is as follows:
 
     Inputs Options:
     --reference         Reference file (fasta, can be .gz-compressed)
-    --gtf               Annotation file (GTF, can be .gz-compressed)
+    --annotation        Annotation file (GTF, can be .gz-compressed)
 
     Read Length Options:
     Use either:


### PR DESCRIPTION
## Overview

Fixes small typo on the usage section where it reads `gtf` but it should read `annotation`
